### PR TITLE
Add more predictible function to get js source

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,9 +304,14 @@ Moonboots.prototype._sendSource = function (type, cb) {
     }
 };
 
+//Legacy method to get JS sourcecode
+Moonboots.prototype.sourceCode = function (cb) {
+    this.jsSource(cb);
+};
+
 // Returns with the JS sourcecode
 // minified, if appropriate
-Moonboots.prototype.sourceCode = function (cb) {
+Moonboots.prototype.jsSource = function (cb) {
     this._sendSource('js', cb);
 };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
             "email": "luke@andyet.net"
         }
     ],
-    "version": "1.1.0",
+    "version": "1.2.0",
     "dependencies": {
         "async": "0.2.9",
         "uglify-js": "2.4.0",


### PR DESCRIPTION
cssSource gets css source, jsSource should get js source

Leaves sourceCode method, no breaking backwards compatibility.
