### PR TITLE
Override styling of html bundle error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ Moonboots.prototype._bundleError = function (err) {
         trace = JSON.stringify(err);
     }
     console.error(trace);
-    this.result.error = 'document.write("<pre>' + trace.split('\n').join('<br>').replace(/"/g, '&quot;') + '</pre>");';
+    this.result.error = 'document.write("<pre style=\'background:#ECFOF2; color:#444; padding: 20px\' >' + trace.split('\n').join('<br>').replace(/"/g, '&quot;') + '</pre>");';
 };
 
 // Returns contactenated external libraries


### PR DESCRIPTION
The html error message styling in andbang is white on light grey thanks to the default styling of &!. Force the pre tag to have a light grey bg color, and dark grey text: 

![](https://i.cloudup.com/9SazO9gO9G-1200x1200.jpeg)
