### PR TITLE
allow sourceMaps option to set browserify.debug properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,13 @@ function Moonboots(opts) {
         html: {}
     };
 
-    //Set this but let an explicity set config.browserify.debug override in the next loop
-    this.config.browserify.debug = this.config.sourceMaps;
-
     for (item in opts) {
         this.config[item] = opts[item];
+    }
+
+    // Use sourceMaps option to set browserify.debug if its not set already
+    if (typeof this.config.browserify.debug === 'undefined') {
+        this.config.browserify.debug = this.config.sourceMaps;
     }
 
     //developmentMode forces minify to false and never build no matter what

--- a/test/sourceMaps.js
+++ b/test/sourceMaps.js
@@ -1,0 +1,56 @@
+var Lab = require('lab');
+var Moonboots = require('..');
+var moonboots;
+
+Lab.experiment('sourceMaps option sets browserify.debug', function () {
+    Lab.before(function (done) {
+        var options = {
+            main: __dirname + '/../fixtures/app/app.js',
+            jsFileName: 'app',
+            sourceMaps: true
+        };
+        moonboots = new Moonboots(options);
+        moonboots.on('ready', done);
+    });
+
+    Lab.test('filename', function (done) {
+        Lab.expect(moonboots.config.browserify.debug).to.equal(true);
+        done();
+    });
+});
+
+Lab.experiment('default is false', function () {
+    Lab.before(function (done) {
+        var options = {
+            main: __dirname + '/../fixtures/app/app.js',
+            jsFileName: 'app'
+        };
+        moonboots = new Moonboots(options);
+        moonboots.on('ready', done);
+    });
+
+    Lab.test('filename', function (done) {
+        Lab.expect(moonboots.config.browserify.debug).to.equal(false);
+        done();
+    });
+});
+
+Lab.experiment('sourceMaps option can be overwritten by browserify.debug', function () {
+    Lab.before(function (done) {
+        var options = {
+            main: __dirname + '/../fixtures/app/app.js',
+            jsFileName: 'app',
+            sourceMaps: true,
+            browserify: {
+                debug: false
+            }
+        };
+        moonboots = new Moonboots(options);
+        moonboots.on('ready', done);
+    });
+
+    Lab.test('filename', function (done) {
+        Lab.expect(moonboots.config.browserify.debug).to.equal(false);
+        done();
+    });
+});


### PR DESCRIPTION
Fixes #37 

Previously `sourceMaps: true` would not set `browserify.debug` to true.
