### PR TITLE
Log css errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,10 @@ Moonboots.prototype.bundleCSS = function (setHash, done) {
             self.timing('buildCSS finish');
             next();
         }
-    ], function _bundleCSSDone() {
+    ], function _bundleCSSDone(err) {
+        if (err) {
+            self.emit('log', ['moonboots', 'error'], err);
+        }
         done(null, self.result.css.source);
     });
 };

--- a/test/css.js
+++ b/test/css.js
@@ -117,3 +117,26 @@ Lab.experiment('sync beforeBuildCSS', function () {
         done();
     });
 });
+
+Lab.experiment('bad css', function () {
+    Lab.before(function (done) {
+        var bad_css = {
+            main: __dirname + '/../fixtures/app/app.js',
+            cssFileName: 'app',
+            stylesheets: [
+                __dirname + '/../fixtures/stylesheets/style.css'
+            ],
+            beforeBuildCSS: function (done) {
+                done('Could not build css');
+            }
+        };
+        moonboots = new Moonboots(bad_css);
+        moonboots.on('ready', done);
+    });
+    Lab.test('empty css, no crashing', function (done) {
+        moonboots.cssSource(function (err, css) {
+            Lab.expect(css, 'css source').to.equal(undefined);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Originally we were going to try to css escape the error and use fancy css to make it show up .before the body, but at least this will let people SEE the error till then. Right now it just silently fails.
