### PR TITLE
Also pass browserify config on browserify init

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ Moonboots.prototype.browserify = function (setHash, done) {
     // so we can use its resolve fn to get a predictable hash from module-deps
     bundle = browserify(self.config.browserify);
     if (setHash) {
-        hashBundle = browserify();
+        hashBundle = browserify(self.config.browserify);
     }
 
     // handle module folder that you want to be able to require without relative paths.


### PR DESCRIPTION
Some options mentioned in [browserify-documentation](https://github.com/substack/node-browserify/tree/4.2.3#var-b--browserifyfiles-or-opts) can only be set on the init of browserify, not passed on the bundle method. Now both is done…
