### PR TITLE
test for consistent hash

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -3,3 +3,4 @@ sample
 fixtures/build1/app.deadbeef.min.js
 fixtures/app/app.js
 fixtures/app/badapp.js
+fixtures/app/appImports.js

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-		@node node_modules/lab/bin/lab -t 100
+		@node node_modules/lab/bin/lab -t 100 -m 10000
 test-no-cov:
 		@node node_modules/lab/bin/lab
 test-cov-html:

--- a/fixtures/app/appImports.js
+++ b/fixtures/app/appImports.js
@@ -1,0 +1,8 @@
+var foo = require('../modules/foo');
+var bar = require('../modules/bar');
+var baz = require('../modules/baz');
+
+
+(function () {
+    console.log(1);
+})();

--- a/fixtures/modules/bar.js
+++ b/fixtures/modules/bar.js
@@ -1,0 +1,8 @@
+var baz = require('./baz');
+var Backbone = require('backbone');
+
+
+module.exports = function () {
+    baz.apply(null, arguments);
+    return Backbone;
+};

--- a/fixtures/modules/baz.js
+++ b/fixtures/modules/baz.js
@@ -1,0 +1,5 @@
+var async = require('async');
+
+module.exports = function (arr, iterator, done) {
+    async.map([1, 2, 3], iterator, done);
+};

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ var browserify = require('browserify');
 var UglifyJS = require('uglify-js');
 var cssmin = require('cssmin');
 var path = require('path');
-var mdeps = require('module-deps');
-var meta = require('bundle-metadata');
 
 
 function Moonboots(opts) {
@@ -273,16 +271,15 @@ Moonboots.prototype.bundleJS = function (setHash, done) {
             //Start w/ external libraries
             self.timing('build libraries start');
             self.result.js.source = concatFiles(self.config.libraries);
-            jssha.update(self.result.js.source);
             self.timing('build libraries finish');
             next();
         },
         function (next) {
-            self.browserify(setHash, next);
+            self.browserify(next);
         },
         function (next) {
             if (setHash) {
-                jssha.update(self.result.js.bundleHash);
+                jssha.update(self.result.js.source);
                 self.result.js.hash = jssha.digest('hex').slice(0, 8);
             }
             if (self.config.minify) {
@@ -304,19 +301,12 @@ Moonboots.prototype.bundleJS = function (setHash, done) {
 };
 
 
-Moonboots.prototype.browserify = function (setHash, done) {
-    var modules, args, bundle, hashBundle;
+Moonboots.prototype.browserify = function (done) {
+    var modules, args, bundle;
     var self = this;
 
     self.timing('browserify start');
-    // Create two bundles:
-    // bundle is to get the actual js source from a browserify bundle
-    // hashBundle is to create a copy of our other bundle (with the same requires and transforms)
-    // so we can use its resolve fn to get a predictable hash from module-deps
     bundle = browserify();
-    if (setHash) {
-        hashBundle = browserify();
-    }
 
     // handle module folder that you want to be able to require without relative paths.
     if (self.config.modulesDir) {
@@ -328,9 +318,6 @@ Moonboots.prototype.browserify = function (setHash, done) {
                     {expose: path.basename(moduleFileName, '.js')}
                 ];
                 bundle.require.apply(bundle, args);
-                if (setHash) {
-                    hashBundle.require.apply(hashBundle, args);
-                }
             }
         });
     }
@@ -339,9 +326,6 @@ Moonboots.prototype.browserify = function (setHash, done) {
     if (self.config.browserify.transforms) {
         self.config.browserify.transforms.forEach(function (tr) {
             bundle.transform(tr);
-            if (setHash) {
-                hashBundle.transform(tr);
-            }
         });
     }
 
@@ -358,19 +342,6 @@ Moonboots.prototype.browserify = function (setHash, done) {
                 self.result.js.source = self.result.js.source + js;
                 next(err);
             });
-        },
-        function (next) {
-            if (!setHash) {
-                return next();
-            }
-            // Get a predictable hash for the bundle
-            mdeps(self.config.main, {
-                resolve: hashBundle._resolve.bind(hashBundle)
-            })
-            .pipe(meta().on('hash', function (hash) {
-                self.result.js.bundleHash = hash;
-                next();
-            }));
         },
     ], function (err) {
         self.timing('browserify finish');

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   "dependencies": {
     "async": "^0.7.0",
     "browserify": "^4.2.1",
-    "bundle-metadata": "^1.0.1",
     "cssmin": "^0.4.1",
-    "module-deps": "^1.8.0",
     "uglify-js": "^2.4.0"
   },
   "devDependencies": {

--- a/test/build.js
+++ b/test/build.js
@@ -103,7 +103,7 @@ Lab.experiment('Files get written to build directory', function () {
     Lab.after(function (done) {
         async.series([
             function (next) {
-                fs.unlink(path.join(buildDir, 'app.4cec31a9.min.js'), next);
+                fs.unlink(path.join(buildDir, 'app.349d0e9e.min.js'), next);
             },
             function (next) {
                 fs.unlink(path.join(buildDir, 'app.38ea6c96.min.css'), next);
@@ -119,7 +119,7 @@ Lab.experiment('Files get written to build directory', function () {
     Lab.test('js file was written', function (done) {
         var jsFileName = moonboots.jsFileName();
         var filePath = path.join(buildDir, jsFileName);
-        Lab.expect(jsFileName).to.equal('app.4cec31a9.min.js');
+        Lab.expect(jsFileName).to.equal('app.349d0e9e.min.js');
         fs.readFile(filePath, 'utf8', function (err) {
             Lab.expect(err).to.not.be.ok;
             // Test that iife-no-semicolon.js doesn't introduce a parsing bug

--- a/test/consistentHash.js
+++ b/test/consistentHash.js
@@ -1,0 +1,51 @@
+var Lab = require('lab');
+var async = require('async');
+var Moonboots = require('..');
+
+function arrEqual(arr) {
+    if (arr.length > 0) {
+        for (var i = 1; i < arr.length; i++) {
+            if (arr[i] !== arr[0]) {
+                return arr[i];
+            }
+        }
+    } 
+    return true;
+}
+
+
+Lab.experiment('Hash is the same', function () {
+    function setup(done) {
+        var options = {
+            main: __dirname + '/../fixtures/app/appImports.js',
+            jsFileName: 'app',
+            minify: false
+        };
+        var moonboots = new Moonboots(options);
+        moonboots.on('ready', function () {
+            done(moonboots);
+        });
+    }
+
+    Lab.test('50 times', function (done) {
+        async.timesSeries(50, function (index, next) {
+            setup(function (moonboots) {
+                var filename = moonboots.jsFileName();
+                moonboots.jsSource(function (err, js) {
+                    next(null, [filename, js]);
+                });
+            });
+        }, function (err, results) {
+            var filenames = results.map(function (r) {
+                return r[0];
+            });
+            var js = results.map(function (r) {
+                return r[1];
+            });
+            Lab.expect(filenames[0]).to.equal('app.f21e12fd.js');
+            Lab.expect(arrEqual(filenames)).to.equal(true);
+            Lab.expect(arrEqual(js)).to.equal(true);
+            done();
+        });
+    });
+});

--- a/test/errors.js
+++ b/test/errors.js
@@ -27,7 +27,7 @@ Lab.experiment('error states', function () {
         });
         moonboots.on('ready', function () {
             var context = moonboots.htmlContext();
-            Lab.expect(context.jsFileName).to.equal('app.882ddd9b.min.js');
+            Lab.expect(context.jsFileName).to.equal('app.321ef2c9.min.js');
             done();
         });
     });
@@ -41,7 +41,7 @@ Lab.experiment('error states', function () {
         });
         moonboots.on('ready', function () {
             var context = moonboots.htmlContext();
-            Lab.expect(context.jsFileName).to.equal('app.882ddd9b.min.js');
+            Lab.expect(context.jsFileName).to.equal('app.321ef2c9.min.js');
             done();
         });
     });
@@ -52,7 +52,7 @@ Lab.experiment('error states', function () {
         });
         moonboots.on('ready', function () {
             var context = moonboots.htmlContext();
-            Lab.expect(context.jsFileName).to.equal('app.882ddd9b.min.js');
+            Lab.expect(context.jsFileName).to.equal('app.9f5c9a18.min.js');
             done();
         });
     });

--- a/test/html.js
+++ b/test/html.js
@@ -18,13 +18,13 @@ Lab.experiment('html with default options', function () {
     Lab.test('htmlContext', function (done) {
         var context = moonboots.htmlContext();
         Lab.expect(context).to.have.keys('jsFileName', 'cssFileName');
-        Lab.expect(context.jsFileName).to.equal('app.882ddd9b.min.js');
+        Lab.expect(context.jsFileName).to.equal('app.321ef2c9.min.js');
         Lab.expect(context.cssFileName).to.equal('app.38ea6c96.min.css');
         done();
     });
     Lab.test('htmlSource', function (done) {
         var source = moonboots.htmlSource();
-        Lab.expect(source).to.equal('<!DOCTYPE html>\n<link href=\"/app.38ea6c96.min.css\" rel=\"stylesheet\" type=\"text/css\">\n<script src=\"/app.882ddd9b.min.js\"></script>');
+        Lab.expect(source).to.equal('<!DOCTYPE html>\n<link href=\"/app.38ea6c96.min.css\" rel=\"stylesheet\" type=\"text/css\">\n<script src=\"/app.321ef2c9.min.js\"></script>');
         done();
     });
 });

--- a/test/js.js
+++ b/test/js.js
@@ -13,7 +13,7 @@ Lab.experiment('js with default options', function () {
         moonboots.on('ready', done);
     });
     Lab.test('filename', function (done) {
-        Lab.expect(moonboots.jsFileName(), 'js filename').to.equal('app.882ddd9b.min.js');
+        Lab.expect(moonboots.jsFileName(), 'js filename').to.equal('app.321ef2c9.min.js');
         done();
     });
     /*
@@ -35,7 +35,7 @@ Lab.experiment('js with no minify', function () {
         moonboots.on('ready', done);
     });
     Lab.test('filename', function (done) {
-        Lab.expect(moonboots.jsFileName(), 'js filename').to.equal('app.882ddd9b.js');
+        Lab.expect(moonboots.jsFileName(), 'js filename').to.equal('app.321ef2c9.js');
         done();
     });
     /*
@@ -56,7 +56,7 @@ Lab.experiment('js with .js already added', function () {
         moonboots.on('ready', done);
     });
     Lab.test('filename', function (done) {
-        Lab.expect(moonboots.jsFileName(), 'js filename').to.equal('app.882ddd9b.min.js');
+        Lab.expect(moonboots.jsFileName(), 'js filename').to.equal('app.321ef2c9.min.js');
         done();
     });
 });


### PR DESCRIPTION
I was working on switching to browserify v5 and it changed some internal APIs so the method for doing the second bundle to get a consistent hash wasn't working.

So while I was trying to figure out another way to do it, I added a test. And I couldn't get it to fail. So I reverted everything and kept the test, and even if I removed the second bundle the test always passed. The browserify bundle was the exact same, even when running 50x. Previously when @nlf and I were testing there was always a hash difference when running that many times.

I also tested against the same codebase as I did in #11 originally and after 100x the hash was always the same.

Anyway, if anyone can break this test, that'd be great :smile: But getting this merged would make updating to browserify v5 much easier.
