### PR TITLE
Throw on build error if in production mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,6 +301,8 @@ Moonboots.prototype.bundleJS = function (setHash, done) {
             self.emit('log', ['moonboots', 'error'], err);
             if (self.config.developmentMode) {
                 self.result.js.source = errorTrace(err);
+            } else {
+                throw err;
             }
         }
         done(null, self.result.js.source);


### PR DESCRIPTION
Currently in production mode you'll get a undefined file with nothing in it if there's a build error. It'd be much better to just throw here.
