### PR TITLE
Call transforms when computing file hash

### DIFF
--- a/fixtures/app/appJadeImport.js
+++ b/fixtures/app/appJadeImport.js
@@ -1,0 +1,6 @@
+require('../modules/qux.jade');
+
+
+(function () {
+    console.log(1);
+})();

--- a/fixtures/modules/qux.jade
+++ b/fixtures/modules/qux.jade
@@ -1,0 +1,1 @@
+p All that you require to crash

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "backbone": "^1.0.0",
     "lab": "^3.0.0",
     "precommit-hook": "^0.3.10",
-    "through": "^2.3.4"
+    "through": "^2.3.4",
+    "jadeify": "2.7.0"
   },
   "homepage": "https://github.com/henrikjoreteg/moonboots",
   "keywords": [

--- a/test/jade.js
+++ b/test/jade.js
@@ -1,0 +1,30 @@
+var Lab = require('lab');
+var Moonboots = require('..');
+var moonboots;
+
+
+Lab.experiment('Jade transform', function () {
+    var moonbootsRan = 0;
+    Lab.before(function (done) {
+        var options = {
+            main: __dirname + '/../fixtures/app/appJadeImport.js',
+            jsFileName: 'app',
+            browserify: {
+                transforms: ['jadeify']
+            }
+        };
+        moonboots = new Moonboots(options);
+        moonboots.on('ready', 
+                    function () {
+                        moonbootsRan++;
+                        done();
+                    }
+        );
+    });
+    Lab.test('ran', function (done) {
+        Lab.expect(moonbootsRan).to.equal(1);
+        done();
+    });
+});
+
+

--- a/test/js.js
+++ b/test/js.js
@@ -123,7 +123,25 @@ Lab.experiment('transforms', function () {
         moonboots.on('ready', done);
     });
     Lab.test('ran', function (done) {
-        Lab.expect(transformRan).to.equal(1);
+        Lab.expect(transformRan).to.equal(2);
+        done();
+    });
+});
+
+Lab.experiment('no transform - for coverage', function () {
+    var transformRan = 0;
+    Lab.before(function (done) {
+        var options = {
+            main: __dirname + '/../fixtures/app/app.js',
+            jsFileName: 'app',
+            browserify: {
+            }
+        };
+        moonboots = new Moonboots(options);
+        moonboots.on('ready', done);
+    });
+    Lab.test('ran', function (done) {
+        Lab.expect(transformRan).to.equal(0);
         done();
     });
 });


### PR DESCRIPTION
Ensure that transforms such as jadeify are called when computing the file hash. Otherwise module-deps can crash due to errors in parsing non-javascript source code
