### PR TITLE
allow setting individual transform options by passing in an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,9 +347,17 @@ Moonboots.prototype.browserify = function (setHash, done) {
 
     // handle browserify transforms if passed
     self.config.browserify.transforms.forEach(function (tr) {
-        bundle.transform(tr);
+        var transform, opts;
+        if (Array.isArray(tr)) {
+            transform = tr[0];
+            opts = tr[1];
+        } else {
+            transform = tr;
+            opts = {};
+        }
+        bundle.transform(transform, opts);
         if (setHash) {
-            hashBundle.transform(tr);
+            hashBundle.transform(transform, opts);
         }
     });
 

--- a/test/jade.js
+++ b/test/jade.js
@@ -1,29 +1,35 @@
 var Lab = require('lab');
 var Moonboots = require('..');
-var moonboots;
+var options = function (transform) {
+    return {
+        main: __dirname + '/../fixtures/app/appJadeImport.js',
+        developmentMode: true,
+        jsFileName: 'app',
+        browserify: {
+            transforms: [transform]
+        }
+    };
+};
 
 
 Lab.experiment('Jade transform', function () {
-    var moonbootsRan = 0;
-    Lab.before(function (done) {
-        var options = {
-            main: __dirname + '/../fixtures/app/appJadeImport.js',
-            jsFileName: 'app',
-            browserify: {
-                transforms: ['jadeify']
-            }
-        };
-        moonboots = new Moonboots(options);
-        moonboots.on('ready', 
-                    function () {
-                        moonbootsRan++;
-                        done();
-                    }
-        );
-    });
     Lab.test('ran', function (done) {
-        Lab.expect(moonbootsRan).to.equal(1);
-        done();
+        var moonboots = new Moonboots(options('jadeify'));
+        moonboots.on('ready', function () {
+            moonboots.jsSource(function (err, js) {
+                Lab.expect(js).to.contain('"<p>All that you require to crash</p>"');
+                done();
+            });
+        });
+    });
+    Lab.test('ran with pretty:true', function (done) {
+        var moonboots = new Moonboots(options(['jadeify', {pretty: true}]));
+        moonboots.on('ready', function () {
+            moonboots.jsSource(function (err, js) {
+                Lab.expect(js).to.contain('"\\n<p>All that you require to crash</p>"');
+                done();
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Browserify allows transforms to have options used like `bundle.transform(transform, options)`.

The syntax to use these in the browserify key of a package.json file is `[transform, options]`. This PR allows the same syntax to be used with the `browserify.transforms` config option. The old syntax is still supported.

Here's an example of using it with `jadeify` to pass in options:

**Old (still supported)**
```js
{
  browserify: {
    transforms: ['jadeify']
  }
}
```

**New**
```js
{
  browserify: {
    transforms: [['jadeify', {pretty: true}]]
  }
}
```

